### PR TITLE
Change the color of the help message

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -156,6 +156,10 @@ body {
     .help {
         flex-basis: 100%;
     }
+    
+    .is-warning {
+        color: #773333;
+    }
 }
 
 .feather-icon {


### PR DESCRIPTION
Currently it's light yellow on white, which is not readable.

Randomly chosen dark red color. Not sure it's in the appropriate section of the css.